### PR TITLE
Update XAPIViewer.js

### DIFF
--- a/1.0/original_prototypes/ReportSample/scripts/XAPIViewer.js
+++ b/1.0/original_prototypes/ReportSample/scripts/XAPIViewer.js
@@ -85,8 +85,10 @@ function getVerb(verb) {
     if (verb === undefined) {
         return "";
     }
-    if (verb.display["en-US"] !== undefined) {
-        return verb.display["en-US"];
+    if (verb.display !== undefined){
+        if (verb.display["en-US"] !== undefined) {
+            return verb.display["en-US"];
+        }        
     }
     if (verb.id !== undefined) {
         return verb.id;


### PR DESCRIPTION
fixes error when no en-us display key given
